### PR TITLE
Cache images by default

### DIFF
--- a/UIImageView+AFNetworking.swift
+++ b/UIImageView+AFNetworking.swift
@@ -104,6 +104,7 @@ extension UIImageView {
                         else {
                             self.image = image!
                         }
+                        UIImageView.sharedImageCache().cacheImage(image!, forRequest: request)
                     }
                     else {
                         if failure != nil {


### PR DESCRIPTION
I noticed that images are not cache by default; while I think this is expected behaviour by implementers of the code?
